### PR TITLE
Apply Rust idioms

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,7 @@ fn main() -> Result<(), Error> {
     let recursive = matches.is_present("recursive");
     let pretty_print = matches.is_present("pretty_print");
 
-    if matches.value_of("path") != None {
-        let directory_path = matches.value_of("path").unwrap();
+    if let Some(directory_path) = matches.value_of("path") {
         let root_path = Path::new(directory_path);
 
         if root_path.is_dir() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn main() -> Result<(), Error> {
             eprintln!("Invalid directory.");
             Result::Err(Error::new(
                 ErrorKind::InvalidInput,
-                "Invalid directory: ".to_string() + directory_path,
+                format!("Invalid directory: {}", directory_path),
             ))
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,13 @@ struct PathNode {
     name: String,
     relative_path: String,
     absolute_path: String,
-    node_type: String,
+    node_type: NodeType,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+enum NodeType {
+    File,
+    Directory,
 }
 
 fn main() -> Result<(), Error> {
@@ -62,7 +68,7 @@ fn main() -> Result<(), Error> {
 
             let root_node = arena.new_node(PathNode {
                 name: directory_path.to_string(),
-                node_type: "Directory".to_string(),
+                node_type: NodeType::Directory,
                 relative_path: directory_path.to_string(),
                 absolute_path: absolute_path.display().to_string(),
             });
@@ -110,7 +116,7 @@ fn traverse(
                 name: String::from(temp_path.file_name().unwrap().to_str().unwrap()),
                 relative_path: String::from(entry.as_str()),
                 absolute_path: absolute_path.display().to_string(),
-                node_type: String::from("Directory"),
+                node_type: NodeType::Directory,
             });
 
             parent.append(dir_object, arena);
@@ -123,7 +129,7 @@ fn traverse(
                 name: String::from(temp_path.file_name().unwrap().to_str().unwrap()),
                 relative_path: String::from(entry.as_str()),
                 absolute_path: absolute_path.display().to_string(),
-                node_type: String::from("File"),
+                node_type: NodeType::File,
             });
 
             parent.append(file_object, arena);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,31 +35,21 @@ fn main() -> Result<(), Error> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("p")
+            Arg::with_name("pretty_print")
                 .short("p")
                 .multiple(false)
                 .help("Enable pretty JSON print output"),
         )
         .arg(
-            Arg::with_name("r")
+            Arg::with_name("recursive")
                 .short("r")
                 .multiple(false)
                 .help("Traverse hierarchy recursively"),
         )
         .get_matches();
 
-    let pretty_print;
-    let recursive;
-
-    match matches.occurrences_of("r") {
-        0 => recursive = false,
-        1 | _ => recursive = true,
-    }
-
-    match matches.occurrences_of("p") {
-        0 => pretty_print = false,
-        1 | _ => pretty_print = true,
-    }
+    let recursive = matches.is_present("recursive");
+    let pretty_print = matches.is_present("pretty_print");
 
     if matches.value_of("path") != None {
         let directory_path = matches.value_of("path").unwrap();


### PR DESCRIPTION
I saw your blog post and had a look on the code. While reading it, I found some sections where you can apply Rust idioms for improvement:

* Run `cargo fmt` to apply indentation guidelines.
* Unpack `Option` using if-let constructs.
* Improve command parsing using some `clap` features.
* Use an `enum` to represent `node_type`
* Construct `String` using the `format!` macro instead of concatenation using `+`.

I changed no functionality, this PR is just some refactoring. Changes are split by commit for easier review.